### PR TITLE
Fix: do not force ROOTFS location for Yocto builds

### DIFF
--- a/build_conf.py
+++ b/build_conf.py
@@ -89,9 +89,6 @@ class BuildConf(object):
 	def get_dir_yocto_build(self):
 		return os.path.join(self.get_dir_build(), 'build')
 
-	def get_dir_yocto_rootfs(self):
-		return os.path.join(self.get_dir_yocto_build(), 'rootfs')
-
 	def get_dir_yocto_deploy(self):
 		return os.path.join(self.get_dir_yocto_build(), 'deploy')
 
@@ -102,7 +99,7 @@ class BuildConf(object):
 		return os.path.join(self.get_dir_yocto_build(), 'buildhistory')
 
 	def get_dir_yocto_shared_rootfs(self):
-		return os.path.join(self.get_dir_yocto_rootfs(), 'shared_rootfs')
+		return os.path.join(self.get_dir_yocto_build(), 'shared_rootfs')
 
 	# build options
 	def get_opt_generate_local_conf(self):

--- a/build_prod.py
+++ b/build_prod.py
@@ -163,7 +163,6 @@ def build_init(cfg):
 		f = open(os.path.join('build', 'conf', 'local.conf'), "w+t")
 		f.write('MACHINE = "' + cfg.get_opt_machine_type() + '"\n')
 		f.write('DL_DIR = "' + cfg.get_dir_yocto_downloads() + '"\n')
-		f.write('IMAGE_ROOTFS = "' + cfg.get_dir_yocto_rootfs() + '"\n')
 		f.write('DEPLOY_DIR = "' + cfg.get_dir_yocto_deploy() + '"\n')
 		f.write('BUILDHISTORY_DIR = "' + cfg.get_dir_yocto_buildhistory() + '"\n')
 		f.write('XT_SSTATE_CACHE_MIRROR_DIR = "' + cfg.get_dir_yocto_sstate_mirror() + '"\n')


### PR DESCRIPTION
There is no value in having built rootfs at some
predefined location. What is more, when multiple
images are built by the inner Yocto it makes
it impossible to do so because of rootfs clashes.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>