### PR TITLE
Allow setting SSTATE_DIR

### DIFF
--- a/README
+++ b/README
@@ -69,6 +69,12 @@ configuration file. Sections and values of the configuration file:
                                    This is also used to store downloads and
                                    shared sstate cache (can be shared with
                                    other machines as sstate cache mirror).
+    - workspace_cache_base_dir   - place where Yocto's SSTATE_DIR or ccache's
+                                   cache directories of the build are stored.
+                                   On machines which do not have enough room
+                                   on fast drives to hold both build itself and
+                                   caches this allows distributing those between
+                                   different storages.
 
 Example of artifacts placement in the storage folder
 ====================================================

--- a/build_conf.py
+++ b/build_conf.py
@@ -45,6 +45,7 @@ CFG_OPTION_XT_MANIFEST = "xt_manifest_uri"
 CFG_SECTION_PATH = "path"
 CFG_OPTION_WORKSPACE_DIR = "workspace_base_dir"
 CFG_OPTION_STORAGE_DIR = "workspace_storage_base_dir"
+CFG_OPTION_CACHE_DIR = "workspace_cache_base_dir"
 
 class BuildConf(object):
 	def get_dir_build(self):
@@ -52,6 +53,9 @@ class BuildConf(object):
 
 	def get_dir_storage(self):
 		return self.__workspace_storage_base_dir
+
+	def get_dir_cache(self):
+		return self.__workspace_cache_base_dir
 
 	# URI of the git repo with build history
 	def get_uri_xt_history(self):
@@ -85,6 +89,9 @@ class BuildConf(object):
 	# so it can be used as SSTATE_MIRROR by others
 	def get_dir_yocto_sstate_mirror(self):
 		return os.path.join(self.get_dir_storage(), 'sstate-cache')
+
+	def get_dir_yocto_sstate(self):
+		return os.path.join(self.get_dir_cache(), 'current-build-cache')
 
 	def get_dir_yocto_build(self):
 		return os.path.join(self.get_dir_build(), 'build')
@@ -182,6 +189,8 @@ class BuildConf(object):
 		self.__workspace_base_dir = os.path.join(os.sep, 'tmp', 'build-ssd')
 		# place where we store files which can be re-used
 		self.__workspace_storage_base_dir = os.path.join(os.sep, 'tmp', 'build-hdd')
+		# place where we store Yocto's sstate and ccache
+		self.__workspace_cache_base_dir = os.path.join(os.sep, 'tmp', 'build-ssd')
 
 		# URI of the git repo with build history
 		self.__xt_history_uri = 'ssh://git@git.epam.com/epmd-aepr/build-history.git'
@@ -197,6 +206,9 @@ class BuildConf(object):
 			uri = config.get(CFG_SECTION_PATH, CFG_OPTION_STORAGE_DIR, 1)
 			if uri:
 				self.__workspace_storage_base_dir = uri
+			uri = config.get(CFG_SECTION_PATH, CFG_OPTION_CACHE_DIR, 1)
+			if uri:
+				self.__workspace_cache_base_dir = uri
 			uri = config.get(CFG_SECTION_GIT, CFG_OPTION_XT_HISTORY, 1)
 			if uri:
 				self.__xt_history_uri = uri
@@ -214,3 +226,4 @@ class BuildConf(object):
 			datetime.datetime.now().strftime('%H-%M-%S'))
 		BuildConf.setup_dir(self.get_dir_build(), not self.__args.continue_build)
 		BuildConf.setup_dir(self.get_dir_storage())
+		BuildConf.setup_dir(self.get_dir_yocto_sstate(), not self.__args.continue_build)

--- a/build_prod.py
+++ b/build_prod.py
@@ -165,6 +165,7 @@ def build_init(cfg):
 		f.write('DL_DIR = "' + cfg.get_dir_yocto_downloads() + '"\n')
 		f.write('DEPLOY_DIR = "' + cfg.get_dir_yocto_deploy() + '"\n')
 		f.write('BUILDHISTORY_DIR = "' + cfg.get_dir_yocto_buildhistory() + '"\n')
+		f.write('SSTATE_DIR = "' + cfg.get_dir_yocto_sstate() + '"\n')
 		f.write('XT_SSTATE_CACHE_MIRROR_DIR = "' + cfg.get_dir_yocto_sstate_mirror() + '"\n')
 		f.write('XT_SHARED_ROOTFS_DIR = "' + cfg.get_dir_yocto_shared_rootfs() + '"\n')
 		f.write('XT_POPULATE_SDK = "1"\n')

--- a/xt-build-server.cfg
+++ b/xt-build-server.cfg
@@ -12,3 +12,6 @@ workspace_base_dir = /home/xt/build-workspace
 
 # place where we store files which can be re-used, artifacts storage
 workspace_storage_base_dir = /media/storage
+
+# place where we store SSTATE_DIR and ccache
+workspace_cache_base_dir = /media/storage/tmp


### PR DESCRIPTION
Allow setting the place where Yocto's SSTATE_DIR or ccache's cache directories of the build are stored.