### PR TITLE
Serialize domain builds

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -178,6 +178,7 @@ def build_init(cfg):
         print('Generating local.conf')
         f = open(os.path.join('build', 'conf', 'local.conf'), "w+t")
         f.write('MACHINE = "' + cfg.get_opt_machine_type() + '"\n')
+        f.write('BB_NUMBER_THREADS = "1"\n')
         f.write('DL_DIR = "' + cfg.get_dir_yocto_downloads() + '"\n')
         f.write('DEPLOY_DIR = "' + cfg.get_dir_yocto_deploy() + '"\n')
         f.write('BUILDHISTORY_DIR = "' + cfg.get_dir_yocto_buildhistory() + '"\n')


### PR DESCRIPTION
It is possible that number of domains in the build are
independent and can start building at a time. This may
lead to each inner Yocto set its BB_NUMBER_THREADS to number of
CPUs in the system, making each build compete for CPU.
Run each domain build one by one, so they can exclusively
use all CPUs.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>