### PR TITLE
Set XT_PRODUCT_NAME variable to local.conf

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -191,6 +191,7 @@ def build_init(cfg):
         if cfg.get_opt_populate_sdk():
             f.write('XT_POPULATE_SDK = "1"\n')
         f.write('LOG_DIR = "' + cfg.get_dir_yocto_log() + '"\n')
+        f.write('XT_PRODUCT_NAME = "' + cfg.get_opt_product_type() +'"\n')
         f.close()
     # add meta layers
     bblayers_list = list_directories(cfg.get_dir_build())


### PR DESCRIPTION
XT_PRODUCT_NAME can be used by the upper layer Yocto
build for product related customizations, so export
the name of the product we build.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>