### PR TITLE
Add XT_PRODUCT_SUFFIX variable to local.conf

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -191,6 +191,8 @@ def build_init(cfg):
         if cfg.get_opt_populate_sdk():
             f.write('XT_POPULATE_SDK = "1"\n')
         f.write('LOG_DIR = "' + cfg.get_dir_yocto_log() + '"\n')
+        if cfg.get_opt_product_type().endswith("-src"):
+            f.write('XT_PRODUCT_SUFFIX = "_src"\n')
         f.close()
     # add meta layers
     bblayers_list = list_directories(cfg.get_dir_build())


### PR DESCRIPTION
Make it possible dynamically select product manifest file.
Suffix "_src" lets us to build proprietary graphic from sources.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>