### PR TITLE
Fix: Allow running without local_conf ini section

### DIFF
--- a/build_conf.py
+++ b/build_conf.py
@@ -256,11 +256,13 @@ class BuildConf(object):
             uri = config.get(CFG_SECTION_GIT, CFG_OPTION_XT_MANIFEST, 1)
             if uri:
                 self.__xt_manifest_uri = uri
-            config_items = config.items(CFG_SECTION_CONF)
-            if config_items:
-                self.__xt_local_conf_options = config_items
-            else:
-                self.__xt_local_conf_options = []
+            self.__xt_local_conf_options = []
+            try:
+                config_items = config.items(CFG_SECTION_CONF)
+                if config_items:
+                    self.__xt_local_conf_options = config_items
+            except ConfigParser.NoSectionError:
+                pass
 
     def __init__(self):
         # get build arguments


### PR DESCRIPTION
Trying to run the script with ini file which doesn't have
[local_conf] section results in unhandled exception:

Traceback (most recent call last):
  File "./build_prod.py", line 306, in <module>
    main()
  File "./build_prod.py", line 293, in main
    cfg = build_conf.BuildConf()
  File "/media/build-workspace/prod-devel/build-scripts/build_conf.py", line 268, in __init__
    self.set_work_config()
  File "/media/build-workspace/prod-devel/build-scripts/build_conf.py", line 259, in set_work_config
    config_items = config.items(CFG_SECTION_CONF)
  File "/usr/lib/python2.7/ConfigParser.py", line 642, in items
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'local_conf'

Fix this by handling this use-case.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>