### PR TITLE
Do not remove SSTATE_DIR at any circumstances

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,14 @@ Optional arguments
                         This is useful for building on powerful machines or
                         build servers.
 
+--retain-sstate       - Normally if a new build is started (either with
+                        --with-do-build or without --continue-build) SSTATE_DIR
+                        is removed. If retain argument is provided it is
+                        guaranteed that SSTATE directory is not removed then.
+                        This behaviour is intended for local (non build server)
+                        builds where state caches use is preferred over clean
+                        environment for every day development.
+
 Configuration file
 ==================
 

--- a/build_conf.py
+++ b/build_conf.py
@@ -198,6 +198,9 @@ class BuildConf(object):
         parser.add_argument('--continue-build', action='store_true',
                             dest='continue_build', required=False, default=False,
                             help='Continue existing build if any, do not clean up')
+        parser.add_argument('--retain-sstate', action='store_true',
+                            dest='retain_sstate', required=False, default=False,
+                            help='Do not remove SSTATE_DIR at any circumstances')
         parser.add_argument('--parallel-build', action='store_true',
                             dest='parallel_build', required=False, default=False,
                             help='Allow parallel building of domains')
@@ -274,4 +277,4 @@ class BuildConf(object):
                                                    datetime.datetime.now().strftime('%H-%M-%S'))
         BuildConf.setup_dir(self.get_dir_build(), not self.__args.continue_build)
         BuildConf.setup_dir(self.get_dir_storage())
-        BuildConf.setup_dir(self.get_dir_yocto_sstate(), not self.__args.continue_build)
+        BuildConf.setup_dir(self.get_dir_yocto_sstate(), not (self.__args.continue_build or self.__args.retain_sstate))


### PR DESCRIPTION
Add new "--retain-sstate" command line argument which guarantees
that SSTATE directory is not removed even when setting up a new build.

Normally if a new build is started (either with --with-do-build or
without --continue-build) SSTATE_DIR is removed. If retain argument
is provided it is guaranteed that SSTATE directory is not removed then.

This behaviour is intended for local (non build server) builds where state
caches use is preferred over clean environment for every day development.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>