### PR TITLE
PullRequests for a product

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,9 @@ Optional arguments
                         This is useful for building on powerful machines or
                         build servers.
 
+--prod_pulls          - allow define the list of the pull requests applied to 
+                        the product's meta layer. Example: --prod_pulls "181,245"
+
 Configuration file
 ==================
 

--- a/build_conf.py
+++ b/build_conf.py
@@ -154,6 +154,9 @@ class BuildConf(object):
     def get_opt_reconstr_time(self):
         return self.__args.reconstr_time.strftime('%H-%M-%S')
 
+    def get_prod_pulls(self):
+        return self.__args.prod_pulls
+
     @staticmethod
     def setup_dir(path, remove=False, silent=False):
         # remove the existing one if any
@@ -208,6 +211,10 @@ class BuildConf(object):
                             dest='repo_branch', required=False,
                             default='master',
                             help="Use product's manifest from the branch specified")
+        parser.add_argument('--prod_pulls',
+                            dest='prod_pulls', required=False, default=False,
+                            help="Use to define the list of the pull-requests for product's meta layer.")
+
         known_args, other_args = parser.parse_known_args()
         # now that we know which build it is we can add appropriate options
         if known_args.build_type == TYPE_RECONSTR:


### PR DESCRIPTION
Usage format: --prod_pulls "pull_number1[, pull_number2]"
for example,  to add the pulls 181 and 241 into the build,
the following has to be added to command line --prod_pulls "181, 241"

Known issues:
  1. In case of merge conflict(s) processing is terminated,
     the status of the repository is unpredictable

Implementation details:
- PyGithub library is used to work with GitHub
- build_prod.py is modified with the following functions
  1. verify_pulls: new function, verify if required PR exists
  2. get_pulls_for: new function, get the PRs for the certain repository
  3. handle_pulls_input: new function, transfer required PRs string into integers
  4. apply_pulls: new function, apply PRs to the repository
  5. process_pulls: new function, start the processing of the pull requests
  6. build_init: updated to deploy the remote, switch repository
     to the required branch, or setup the 'master' branch if branch
     is not defined and call process_pulls
- build_conf.py, support of the command line option '--prod_pulls' was added
  functions:
  get_prod_pulls: get the list of the PRs for the build

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>