### PR TITLE
Improve readability of errors

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -364,6 +364,8 @@ def main():
             build_conf.TYPE_RECONSTR: build_reconstr,
         }
         action[cfg.get_opt_build_type()](cfg)
+    except Exception as e:
+        print e
     finally:
         print("Done")
 

--- a/build_prod.py
+++ b/build_prod.py
@@ -49,7 +49,7 @@ def copy_dir(src, dst):
 def bash_run_command(cmd):
     ret = subprocess.call("bash -c '%s'" % cmd, shell=True)
     if ret != 0:
-        raise Exception('Failed to run ' + cmd + ': ' + str(ret))
+        raise Exception('Failed to run "' + cmd + '", error code: ' + str(ret))
 
 # block to work with pull requests
 


### PR DESCRIPTION
Please see output of script with applied patch:
```
Summary: There was 1 WARNING message shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
Failed to run "source xt-distro/oe-init-build-env && bitbake xt-image", error code: 1
Done
```
For reference, output without patch:
```
Summary: There was 1 WARNING message shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
Done
Traceback (most recent call last):
  File "./build_prod.py", line 372, in <module>
    main()
  File "./build_prod.py", line 366, in main
    action[cfg.get_opt_build_type()](cfg)
  File "./build_prod.py", line 317, in build_daily
    build_run(cfg)
  File "./build_prod.py", line 304, in build_run
    yocto_run_command('bitbake ' + bb_target)
  File "./build_prod.py", line 158, in yocto_run_command
    bash_run_command('source ' + src + ' && ' + cmd)
  File "./build_prod.py", line 52, in bash_run_command
    raise Exception('Failed to run ' + cmd + ': ' + str(ret))
Exception: Failed to run source xt-distro/oe-init-build-env && bitbake xt-image: 1
```