### PR TITLE
Allow to use empty strings in local_conf section

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -242,7 +242,10 @@ def generate_local_conf(cfg, reconstruct_dir):
 
         if cfg.get_opt_local_conf():
             for item in cfg.get_opt_local_conf():
-                f.write(item[0].upper() + ' = ' + item[1] + '\n')
+                if item[1]:
+                    f.write(item[0].upper() + ' = ' + item[1] + '\n')
+                else:
+                    f.write(item[0].upper() + ' = ""\n')
         f.close()
 
 


### PR DESCRIPTION
This commit fixes incorrect handling of empty strings assigned
to variables in `local_conf` section of configuration.

If empty string ("") is assigned or nothing is specified after `=`,
config parser uses empty tuple as value. Attempt to write empty
tumple to local.conf of upper yocto results in error.

From now we handle this situation and write empty string for
variable with no value.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>