### PR TITLE
Also expand variable in local.conf section

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -243,7 +243,10 @@ def generate_local_conf(cfg, reconstruct_dir):
         if cfg.get_opt_local_conf():
             for item in cfg.get_opt_local_conf():
                 if item[1]:
-                    f.write(item[0].upper() + ' = ' + item[1] + '\n')
+                    # Try expanding the argument if it uses environment vars
+                    # This also works for non-path arguments
+                    f.write(item[0].upper() + ' = ' +
+                            cfg.expand_path(item[1]) + '\n')
                 else:
                     f.write(item[0].upper() + ' = ""\n')
         f.close()


### PR DESCRIPTION
local.conf section may also use environment variables to set up the
build, e.g. relative paths to some storage, binaries etc.
Make it also possible to expand those variables, so we don't need to
hardcode real paths in this section.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>