### PR TITLE
The path to the manifest of the product is changed.

### DIFF
--- a/build_prod.py
+++ b/build_prod.py
@@ -125,8 +125,9 @@ def buildhistory_commit(cfg):
 
 
 def repo_init(uri, branch, xml_base_name):
+    prod_manifest_path = xml_base_name.replace("-", "_") + "/" + xml_base_name
     bash_run_command('repo init -u %s -b %s -m %s.xml' %
-                     (uri, branch, xml_base_name))
+                     (uri, branch, prod_manifest_path))
 
 
 def repo_sync():


### PR DESCRIPTION
The manifests of the products are moved from meta-xt-images ro manifests

The idea is to collect all manifests in one repository.
There were 2 ways
1. Migrate from manifests to meta-xt-products
2. Migrate from meta-xt-products to the manifests
The second option has been chosen because in the case of option 1
the following needs to be done
-all products have to be modified to change the path to the manifest
-the configure step needs to be done for all products, to be sure that the
    correct manifests have been used

In the case of option 1 it is enough to move the manifests to the corresponded
directories and modify build-scripts/build_prod.py (one line of code)
To test, it is enough just to configure the layout using.

python ./build_prod.py --build-type dailybuild --machine [MACHINE NAME] --product [PRODUCT NAME] --branch [BRANCH OF THE MANIFEST] --with-local-conf --config [PRODUCT COMFIG FILE].cfg


Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>